### PR TITLE
Add E2E integration test skill (JarvisLab + local inferoute-node)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ go.work
 .idea/
 .vscode/
 .cursor/
+!.cursor/skills/
+!.cursor/skills/**
 *.swp
 *.swo
 *~

--- a/skills/inferoute-e2e-integration-test/SKILL.md
+++ b/skills/inferoute-e2e-integration-test/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: inferoute-e2e-integration-test
 description: "End-to-end integration test for inferoute-client (JarvisLab GPU + vLLM) against inferoute-node (local Mac consumer). Uses jl CLI to resume/unpause a JarvisLab instance, SSH/exec to start vLLM and inferoute-client, then runs non-streaming and streaming inference from the Mac. Use when the user says 'test inferoute e2e', 'test client with node', 'JarvisLab integration test', or 'verify provider inference'."
-argument-hint: "[optional: machine_id, model alias, or 'teardown']"
+argument-hint: "[optional: machine_id, model alias, 'keep' to skip pause, or 'teardown']"
 ---
 
 # Inferoute E2E Integration Test (Mac node + JarvisLab provider)
@@ -50,8 +50,8 @@ Key variables:
 | Variable | Example | Purpose |
 |----------|---------|---------|
 | `JL_MACHINE_ID` | `433049` | Paused JarvisLab instance |
-| `INFEROUTE_PLATFORM_URL` | `https://xxxx.ngrok-free.app` | ngrok https URL → Mac docker `:80` |
-| `NGROK_CMD` | `ngrok http 80` | Run on Mac before JarvisLab client |
+| `INFEROUTE_PLATFORM_URL` | `https://saussuritic-ordinarily-sheldon.ngrok-free.dev` | Reserved ngrok domain |
+| `NGROK_CMD` | `ngrok http 80 --host-header=localhost --url=saussuritic-ordinarily-sheldon.ngrok-free.dev` | Run on Mac |
 | `INFEROUTE_CONSUMER_URL` | `http://localhost` | inferoute-node docker on port 80 |
 | `PROVIDER_API_KEY` | `sk-...` | Provider registration / tunnel |
 | `CONSUMER_API_KEY` | `sk-...` | Consumer inference auth |
@@ -85,6 +85,7 @@ Default to **Mode A** when the user says they run inferoute-node on their Mac.
 
 1. Parse `$ARGUMENTS`:
    - `teardown` → jump to Phase 7
+   - `keep` → skip auto-pause after Phase 6
    - machine id → set `JL_MACHINE_ID`
    - model alias → set `INFEROUTE_MODEL_ALIAS`
 2. `source` the env file; fail fast if required vars are empty.
@@ -104,7 +105,7 @@ eval "$NGROK_CMD"
 # OR run the literal command the user gave you
 ```
 
-3. Copy the ngrok **https** forwarding URL into `INFEROUTE_PLATFORM_URL` (no trailing slash).
+3. Copy the ngrok **https** forwarding URL into `INFEROUTE_PLATFORM_URL` if not already set (reserved domain is preconfigured in `env.example`).
 4. Verify tunnel from Mac:
 
 ```bash
@@ -355,19 +356,32 @@ Attach on failure:
 - Last 30 lines of `/home/inferoute/logs/vllm.log`
 - Consumer response body
 
-Ask the user whether to **pause** the instance or leave running for debugging.
+**Default: run Phase 7 teardown** (pause JarvisLab) after reporting results.
 
-### Phase 7: Teardown
+Skip auto-pause only if the user passed `keep` in arguments or explicitly asked to leave the instance running for debugging.
+
+### Phase 7: Teardown (always pauses JarvisLab)
+
+Run `references/teardown.sh` or equivalent:
 
 ```bash
-jl pause "$JL_MACHINE_ID" --yes
+source ~/.config/inferoute/e2e.env
+bash skills/inferoute-e2e-integration-test/references/teardown.sh
 ```
 
-Optionally stop processes before pause:
+What it does:
+
+1. Stop `inferoute-client` and `vllm serve` on the JarvisLab instance (if Running)
+2. **`jl pause "$JL_MACHINE_ID" --yes`** — stops compute billing
+
+Manual equivalent:
 
 ```bash
 jl exec "$JL_MACHINE_ID" -- sh -lc 'pkill -x inferoute-client || true; pkill -f "vllm serve" || true'
+jl pause "$JL_MACHINE_ID" --yes
 ```
+
+Also stop ngrok on the Mac (`Ctrl+C` in the ngrok terminal).
 
 **Do not `jl destroy`** unless the user explicitly requests it.
 
@@ -410,7 +424,8 @@ Exercised indirectly: tunnel request, health push, HMAC validation, model verify
 ## References
 
 - `references/env.example` — environment template
-- `references/test-inference.sh` — Mac-side test runner
+- `references/teardown.sh` — stop processes + **pause JarvisLab** (run after tests or `test inferoute e2e teardown`)
+- `references/test-inference.sh` — Mac-side inference smoke tests
 - `references/jarvislab-provider-setup.sh` — optional reusable JarvisLab bootstrap
 - `references/ngrok.md` — ngrok on Mac (required for Mode A)
 - `references/inferoute-node-local.md` — Mac node startup notes

--- a/skills/inferoute-e2e-integration-test/SKILL.md
+++ b/skills/inferoute-e2e-integration-test/SKILL.md
@@ -34,7 +34,8 @@ Run through this before Phase 1. Stop and ask the user for anything missing.
 | Provider API key | From inferoute platform (provider role) |
 | Consumer API key | From inferoute platform (inference consumer) |
 | Approved model on GPU | Model must exist in approved-builds catalog for `vllm` |
-| Mac reachable from JarvisLab | JarvisLab must reach `provider.url` (see Network modes below) |
+| ngrok on Mac | Exposes local inferoute-node to JarvisLab (`references/ngrok.md`) |
+| Mac reachable from JarvisLab | `INFEROUTE_PLATFORM_URL` = ngrok https URL |
 
 ### Environment file
 
@@ -48,24 +49,27 @@ Key variables:
 
 | Variable | Example | Purpose |
 |----------|---------|---------|
-| `JL_MACHINE_ID` | `12345` | Existing JarvisLab instance to resume |
-| `INFEROUTE_PLATFORM_URL` | `http://<mac-tailscale-ip>:8081` | `provider.url` — must be reachable from JarvisLab |
-| `INFEROUTE_CONSUMER_URL` | `http://localhost:8081` | Mac-local consumer API base |
+| `JL_MACHINE_ID` | `433049` | Paused JarvisLab instance |
+| `INFEROUTE_PLATFORM_URL` | `https://xxxx.ngrok-free.app` | ngrok https URL → Mac docker `:80` |
+| `NGROK_CMD` | `ngrok http 80` | Run on Mac before JarvisLab client |
+| `INFEROUTE_CONSUMER_URL` | `http://localhost` | inferoute-node docker on port 80 |
 | `PROVIDER_API_KEY` | `sk-...` | Provider registration / tunnel |
 | `CONSUMER_API_KEY` | `sk-...` | Consumer inference auth |
-| `VLLM_MODEL` | `Qwen/Qwen3-0.6B` | HuggingFace id for `vllm serve` |
-| `INFEROUTE_MODEL_ALIAS` | platform alias | Alias returned in health / used in requests |
+| `VLLM_MODEL` | `Qwen/Qwen3-0.6B` | `vllm serve` on JarvisLab |
+| `INFEROUTE_MODEL_ALIAS` | `Qwen/Qwen3-0.6B` | Use alias from health if different |
 | `JL_GPU` | `L4` | Optional override on `jl resume` |
 
 ### Network modes
 
 Pick one with the user before starting:
 
-**Mode A — Local inferoute-node (user's stated goal)**
+**Mode A — Local inferoute-node (default)**
 
 - Mac runs inferoute-node (docker compose or `go run`).
-- `INFEROUTE_PLATFORM_URL` must be reachable from JarvisLab (Tailscale, Cloudflare tunnel on Mac, or public IP + port).
-- `INFEROUTE_CONSUMER_URL` is typically `http://localhost:<node-port>` on the Mac.
+- **ngrok on Mac** exposes the platform port to the internet; JarvisLab uses that URL as `provider.url`.
+- Set `INFEROUTE_PLATFORM_URL` to the ngrok **https** URL (see `references/ngrok.md`).
+- `INFEROUTE_CONSUMER_URL` stays `http://localhost` (docker port 80).
+- Default `NGROK_CMD="ngrok http 80"`. User can override in `e2e.env` if their ngrok setup differs.
 
 **Mode B — Hosted platform (simpler connectivity)**
 
@@ -85,6 +89,35 @@ Default to **Mode A** when the user says they run inferoute-node on their Mac.
    - model alias → set `INFEROUTE_MODEL_ALIAS`
 2. `source` the env file; fail fast if required vars are empty.
 3. Confirm network mode (A or B) with the user if `INFEROUTE_PLATFORM_URL` is unset or ambiguous.
+4. If `NGROK_CMD` differs from default, use the value in `e2e.env`.
+
+### Phase 0b: ngrok + inferoute-node on Mac (Mode A only)
+
+Run on the **user's Mac** before resuming JarvisLab.
+
+1. Start inferoute-node locally (see `references/inferoute-node-local.md`).
+2. Start ngrok with the user-provided command:
+
+```bash
+# User provides exact command — stored in NGROK_CMD
+eval "$NGROK_CMD"
+# OR run the literal command the user gave you
+```
+
+3. Copy the ngrok **https** forwarding URL into `INFEROUTE_PLATFORM_URL` (no trailing slash).
+4. Verify tunnel from Mac:
+
+```bash
+curl -sf "$INFEROUTE_PLATFORM_URL/api/health" || curl -sf -o /dev/null -w "%{http_code}\n" "$INFEROUTE_PLATFORM_URL"
+```
+
+5. After JarvisLab is Running (Phase 1), verify from GPU side:
+
+```bash
+jl exec "$JL_MACHINE_ID" -- curl -sf -o /dev/null -w "%{http_code}\n" "$INFEROUTE_PLATFORM_URL/api/health"
+```
+
+**Skip Phase 0b** if using Mode B (`INFEROUTE_PLATFORM_URL=https://core.inferoute.com`).
 
 ### Phase 1: Resume JarvisLab instance
 
@@ -370,7 +403,7 @@ Exercised indirectly: tunnel request, health push, HMAC validation, model verify
 | `401` Missing HMAC | Node not signing requests | Check node → provider routing |
 | `403` model | Not verified | Wait for health cycles; check approved-builds |
 | `502` from client | vLLM down / wrong model id | Check vLLM logs |
-| Client can't reach platform | Network mode A broken | Tailscale/ping from `jl exec` to Mac URL |
+| Client can't reach platform | ngrok down or wrong URL | Restart ngrok; re-check `INFEROUTE_PLATFORM_URL`; `jl exec` curl to ngrok URL |
 | No tunnel URL | cloudflared / platform error | Client logs, `which cloudflared` on JarvisLab |
 | Stream hangs 30s | Client write timeout | Expected on main; try streaming branch |
 
@@ -379,6 +412,7 @@ Exercised indirectly: tunnel request, health push, HMAC validation, model verify
 - `references/env.example` — environment template
 - `references/test-inference.sh` — Mac-side test runner
 - `references/jarvislab-provider-setup.sh` — optional reusable JarvisLab bootstrap
+- `references/ngrok.md` — ngrok on Mac (required for Mode A)
 - `references/inferoute-node-local.md` — Mac node startup notes
 - `config.yaml.example` (repo root) — provider config fields
 - `documentation/technical.md` — client architecture

--- a/skills/inferoute-e2e-integration-test/SKILL.md
+++ b/skills/inferoute-e2e-integration-test/SKILL.md
@@ -1,0 +1,386 @@
+---
+name: inferoute-e2e-integration-test
+description: "End-to-end integration test for inferoute-client (JarvisLab GPU + vLLM) against inferoute-node (local Mac consumer). Uses jl CLI to resume/unpause a JarvisLab instance, SSH/exec to start vLLM and inferoute-client, then runs non-streaming and streaming inference from the Mac. Use when the user says 'test inferoute e2e', 'test client with node', 'JarvisLab integration test', or 'verify provider inference'."
+argument-hint: "[optional: machine_id, model alias, or 'teardown']"
+---
+
+# Inferoute E2E Integration Test (Mac node + JarvisLab provider)
+
+Runs a full-stack smoke test:
+
+```text
+[Local Mac]  inferoute-node (consumer API)
+      │
+      ▼  routes inference + HMAC
+[Platform]   inferoute-node / core.inferoute.com
+      │
+      ▼  Cloudflare tunnel
+[JarvisLab]  inferoute-client :8080 → vLLM :8000
+```
+
+**This skill does not replace unit tests.** It validates live wiring: tunnel, health, model verification, HMAC, and consumer inference (sync + stream).
+
+## Prerequisites checklist
+
+Run through this before Phase 1. Stop and ask the user for anything missing.
+
+| Requirement | How to verify |
+|-------------|---------------|
+| `jl` CLI | `command -v jl && jl --version` |
+| JarvisLab auth | `jl status` (or `JL_API_KEY` set) |
+| SSH key on JarvisLab | `jl ssh-key list` — VM instances require at least one key |
+| Paused JarvisLab instance | `jl list --json` — note `machine_id` |
+| inferoute-node on Mac | User runs local stack (see `references/inferoute-node-local.md`) |
+| Provider API key | From inferoute platform (provider role) |
+| Consumer API key | From inferoute platform (inference consumer) |
+| Approved model on GPU | Model must exist in approved-builds catalog for `vllm` |
+| Mac reachable from JarvisLab | JarvisLab must reach `provider.url` (see Network modes below) |
+
+### Environment file
+
+Copy and fill `references/env.example` → `~/.config/inferoute/e2e.env` (or repo-local `.env.e2e` — never commit secrets).
+
+```bash
+source ~/.config/inferoute/e2e.env
+```
+
+Key variables:
+
+| Variable | Example | Purpose |
+|----------|---------|---------|
+| `JL_MACHINE_ID` | `12345` | Existing JarvisLab instance to resume |
+| `INFEROUTE_PLATFORM_URL` | `http://<mac-tailscale-ip>:8081` | `provider.url` — must be reachable from JarvisLab |
+| `INFEROUTE_CONSUMER_URL` | `http://localhost:8081` | Mac-local consumer API base |
+| `PROVIDER_API_KEY` | `sk-...` | Provider registration / tunnel |
+| `CONSUMER_API_KEY` | `sk-...` | Consumer inference auth |
+| `VLLM_MODEL` | `Qwen/Qwen3-0.6B` | HuggingFace id for `vllm serve` |
+| `INFEROUTE_MODEL_ALIAS` | platform alias | Alias returned in health / used in requests |
+| `JL_GPU` | `L4` | Optional override on `jl resume` |
+
+### Network modes
+
+Pick one with the user before starting:
+
+**Mode A — Local inferoute-node (user's stated goal)**
+
+- Mac runs inferoute-node (docker compose or `go run`).
+- `INFEROUTE_PLATFORM_URL` must be reachable from JarvisLab (Tailscale, Cloudflare tunnel on Mac, or public IP + port).
+- `INFEROUTE_CONSUMER_URL` is typically `http://localhost:<node-port>` on the Mac.
+
+**Mode B — Hosted platform (simpler connectivity)**
+
+- `INFEROUTE_PLATFORM_URL=https://core.inferoute.com`
+- Mac only runs consumer client/SDK against the same platform.
+- Use when local node networking is not set up yet.
+
+Default to **Mode A** when the user says they run inferoute-node on their Mac.
+
+## Workflow
+
+### Phase 0: Resolve scope
+
+1. Parse `$ARGUMENTS`:
+   - `teardown` → jump to Phase 7
+   - machine id → set `JL_MACHINE_ID`
+   - model alias → set `INFEROUTE_MODEL_ALIAS`
+2. `source` the env file; fail fast if required vars are empty.
+3. Confirm network mode (A or B) with the user if `INFEROUTE_PLATFORM_URL` is unset or ambiguous.
+
+### Phase 1: Resume JarvisLab instance
+
+```bash
+jl get "$JL_MACHINE_ID" --json | jq '{status, gpu, ssh_command}'
+jl resume "$JL_MACHINE_ID" --yes ${JL_GPU:+--gpu "$JL_GPU"}
+```
+
+Poll until Running (max ~5 min):
+
+```bash
+until [ "$(jl get "$JL_MACHINE_ID" --json | jq -r '.status')" = "Running" ]; do
+  sleep 10
+  echo "waiting for Running..."
+done
+jl get "$JL_MACHINE_ID" --json | jq '{status, ssh_command, gpu}'
+```
+
+Verify GPU:
+
+```bash
+jl exec "$JL_MACHINE_ID" -- nvidia-smi
+```
+
+### Phase 2: Start vLLM on JarvisLab
+
+Use `jl exec` for idempotent checks; use SSH session (or `tmux` via exec) for long-running servers.
+
+**Check if vLLM already listening:**
+
+```bash
+jl exec "$JL_MACHINE_ID" -- sh -lc 'curl -sf http://127.0.0.1:8000/v1/models | head -c 500'
+```
+
+**If not running, start in background (persist under `/home`):**
+
+```bash
+jl exec "$JL_MACHINE_ID" -- sh -lc '
+  mkdir -p /home/inferoute/logs
+  if ! pgrep -f "vllm serve" >/dev/null; then
+    nohup vllm serve '"$VLLM_MODEL"' \
+      --host 0.0.0.0 --port 8000 \
+      > /home/inferoute/logs/vllm.log 2>&1 &
+  fi
+'
+```
+
+Wait for model (large models may take several minutes):
+
+```bash
+until jl exec "$JL_MACHINE_ID" -- curl -sf http://127.0.0.1:8000/v1/models >/dev/null 2>&1; do
+  sleep 15
+  echo "waiting for vLLM..."
+done
+jl exec "$JL_MACHINE_ID" -- curl -s http://127.0.0.1:8000/v1/models | jq .
+```
+
+**First-time setup** (only if `vllm` missing on instance):
+
+```bash
+jl exec "$JL_MACHINE_ID" -- pip install -q 'vllm>=0.8.0'
+```
+
+Prefer a startup script under `/home/inferoute/` if the instance is reused often (see `references/jarvislab-provider-setup.sh`).
+
+### Phase 3: Install and configure inferoute-client on JarvisLab
+
+**Option 1 — Install script (recommended):**
+
+```bash
+jl exec "$JL_MACHINE_ID" -- sh -lc '
+  export PROVIDER_API_KEY="'"$PROVIDER_API_KEY"'"
+  export PROVIDER_TYPE=vllm
+  export LLM_URL=http://127.0.0.1:8000
+  export SERVER_PORT=8080
+  curl -fsSL https://raw.githubusercontent.com/inferoute/inferoute-client/main/scripts/install.sh | bash
+'
+```
+
+**Option 2 — Upload local build:**
+
+```bash
+jl upload "$JL_MACHINE_ID" ./inferoute-client /home/inferoute/bin/inferoute-client
+```
+
+**Write provider config** (adjust `provider.url` to `INFEROUTE_PLATFORM_URL`):
+
+```bash
+jl exec "$JL_MACHINE_ID" -- sh -lc 'mkdir -p ~/.config/inferoute && cat > ~/.config/inferoute/config.yaml <<EOF
+server:
+  port: 8080
+  host: "0.0.0.0"
+provider:
+  api_key: "'"$PROVIDER_API_KEY"'"
+  url: "'"$INFEROUTE_PLATFORM_URL"'"
+  provider_type: vllm
+  llm_url: http://127.0.0.1:8000
+logging:
+  level: info
+EOF'
+```
+
+**Start client** (if not already running):
+
+```bash
+jl exec "$JL_MACHINE_ID" -- sh -lc '
+  mkdir -p /home/inferoute/logs
+  if ! pgrep -x inferoute-client >/dev/null; then
+    nohup inferoute-client --config ~/.config/inferoute/config.yaml \
+      > /home/inferoute/logs/inferoute-client.log 2>&1 &
+  fi
+'
+```
+
+**Sanity checks on JarvisLab:**
+
+```bash
+jl exec "$JL_MACHINE_ID" -- curl -s http://127.0.0.1:8080/api/health | jq '{provider_type, models: .data[0:3], tunnel: .cloudflare.url}'
+jl exec "$JL_MACHINE_ID" -- curl -s http://127.0.0.1:8080/api/busy
+```
+
+### Phase 4: Wait for platform readiness (Mac side)
+
+On the **Mac** (inferoute-node must be running):
+
+1. **Tunnel registered** — health report shows `cloudflare.url` (check JarvisLab health JSON above).
+2. **Model verified** — `verification_status` is `verified` for the target alias (may take 1–3 health cycles ≈ 3–9 min after first start).
+3. **Model routable** — node lists provider/model for inference.
+
+```bash
+# Example: check node health / provider list (adjust path to your inferoute-node API)
+curl -s -H "Authorization: Bearer $CONSUMER_API_KEY" \
+  "$INFEROUTE_CONSUMER_URL/v1/models" | jq .
+```
+
+If verification stays `pending` or `failed`, inspect:
+
+```bash
+jl exec "$JL_MACHINE_ID" -- tail -80 /home/inferoute/logs/inferoute-client.log
+```
+
+Common causes: weights not in HF cache path, model not in approved-builds, `provider.url` unreachable from JarvisLab.
+
+### Phase 5: Inference tests (Mac consumer → node → client → vLLM)
+
+Run from the **Mac** using `references/test-inference.sh` or the commands below.
+
+**5a. Non-streaming chat completion**
+
+```bash
+curl -s "$INFEROUTE_CONSUMER_URL/v1/chat/completions" \
+  -H "Authorization: Bearer $CONSUMER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "'"$INFEROUTE_MODEL_ALIAS"'",
+    "messages": [{"role": "user", "content": "Reply with exactly: inferoute-ok"}],
+    "stream": false,
+    "max_tokens": 32
+  }' | jq .
+```
+
+**Pass:** HTTP 200, `choices[0].message.content` contains expected text.
+
+**5b. Non-streaming completion** (if node exposes `/v1/completions`)
+
+```bash
+curl -s "$INFEROUTE_CONSUMER_URL/v1/completions" \
+  -H "Authorization: Bearer $CONSUMER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "'"$INFEROUTE_MODEL_ALIAS"'",
+    "prompt": "Reply with exactly: inferoute-ok",
+    "stream": false,
+    "max_tokens": 32
+  }' | jq .
+```
+
+**5c. Streaming chat completion**
+
+```bash
+curl -N "$INFEROUTE_CONSUMER_URL/v1/chat/completions" \
+  -H "Authorization: Bearer $CONSUMER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "'"$INFEROUTE_MODEL_ALIAS"'",
+    "messages": [{"role": "user", "content": "Count from 1 to 5 slowly."}],
+    "stream": true,
+    "max_tokens": 64
+  }'
+```
+
+**Pass:** `Content-Type: text/event-stream` (or chunked SSE), multiple `data: {...}` lines, terminal `data: [DONE]`.
+
+**5d. Streaming completion** (if exposed)
+
+Same as 5c against `/v1/completions` with `"stream": true`.
+
+**5e. OpenAI SDK (optional cross-check)**
+
+```bash
+python3 - <<'PY'
+import os, sys
+from openai import OpenAI
+client = OpenAI(base_url=os.environ["INFEROUTE_CONSUMER_URL"].rstrip("/") + "/v1",
+                api_key=os.environ["CONSUMER_API_KEY"])
+stream = client.chat.completions.create(
+    model=os.environ["INFEROUTE_MODEL_ALIAS"],
+    messages=[{"role": "user", "content": "Say hi in one word"}],
+    stream=True, max_tokens=16)
+for chunk in stream:
+    if chunk.choices and chunk.choices[0].delta.content:
+        sys.stdout.write(chunk.choices[0].delta.content)
+        sys.stdout.flush()
+print()
+PY
+```
+
+### Phase 6: Report results
+
+Emit a concise table:
+
+| Test | Endpoint | Result | Notes |
+|------|----------|--------|-------|
+| Health | JarvisLab `/api/health` | pass/fail | tunnel URL, model status |
+| Chat sync | `/v1/chat/completions` | pass/fail | |
+| Chat stream | `/v1/chat/completions` stream | pass/fail | |
+| Completions sync | `/v1/completions` | pass/fail/skip | |
+| Completions stream | `/v1/completions` stream | pass/fail/skip | |
+
+**Known limitation (inferoute-client @ main):** the provider client **buffers** LLM responses even when `stream: true` — it does not passthrough SSE to the tunnel. Streaming tests in Phase 5 validate **inferoute-node → consumer** behavior. If provider-side streaming fails but sync works, check whether `origin/streaming-cursor-clean` branch should be deployed on JarvisLab.
+
+Attach on failure:
+
+- Last 50 lines of `/home/inferoute/logs/inferoute-client.log`
+- Last 30 lines of `/home/inferoute/logs/vllm.log`
+- Consumer response body
+
+Ask the user whether to **pause** the instance or leave running for debugging.
+
+### Phase 7: Teardown
+
+```bash
+jl pause "$JL_MACHINE_ID" --yes
+```
+
+Optionally stop processes before pause:
+
+```bash
+jl exec "$JL_MACHINE_ID" -- sh -lc 'pkill -x inferoute-client || true; pkill -f "vllm serve" || true'
+```
+
+**Do not `jl destroy`** unless the user explicitly requests it.
+
+## API surface covered
+
+### Consumer (inferoute-node on Mac)
+
+| Method | Path | Phase |
+|--------|------|-------|
+| GET | `/v1/models` | 4 |
+| POST | `/v1/chat/completions` | 5a, 5c |
+| POST | `/v1/completions` | 5b, 5d |
+
+Auth: `Authorization: Bearer $CONSUMER_API_KEY` (confirm header name in your node version).
+
+### Provider (inferoute-client on JarvisLab)
+
+| Method | Path | Phase |
+|--------|------|-------|
+| GET | `/api/health` | 3, 4 |
+| GET | `/api/busy` | 3 |
+| POST | `/v1/chat/completions` | indirect via platform |
+| POST | `/v1/completions` | indirect via platform |
+
+### Platform (inferoute-node backend)
+
+Exercised indirectly: tunnel request, health push, HMAC validation, model verify, routing.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---------|--------------|--------|
+| `401` Missing HMAC | Node not signing requests | Check node → provider routing |
+| `403` model | Not verified | Wait for health cycles; check approved-builds |
+| `502` from client | vLLM down / wrong model id | Check vLLM logs |
+| Client can't reach platform | Network mode A broken | Tailscale/ping from `jl exec` to Mac URL |
+| No tunnel URL | cloudflared / platform error | Client logs, `which cloudflared` on JarvisLab |
+| Stream hangs 30s | Client write timeout | Expected on main; try streaming branch |
+
+## References
+
+- `references/env.example` — environment template
+- `references/test-inference.sh` — Mac-side test runner
+- `references/jarvislab-provider-setup.sh` — optional reusable JarvisLab bootstrap
+- `references/inferoute-node-local.md` — Mac node startup notes
+- `config.yaml.example` (repo root) — provider config fields
+- `documentation/technical.md` — client architecture
+
+**Skill location:** `skills/inferoute-e2e-integration-test/SKILL.md` — symlink or copy to `~/.cursor/skills/inferoute-e2e-integration-test/` for Cursor agent discovery.

--- a/skills/inferoute-e2e-integration-test/references/env.example
+++ b/skills/inferoute-e2e-integration-test/references/env.example
@@ -2,16 +2,19 @@
 # NEVER commit filled secrets.
 
 # JarvisLab
-export JL_MACHINE_ID=""          # jl list --json
+export JL_MACHINE_ID="433049"
 export JL_GPU=""                 # optional: L4, A100, etc.
 
 # Platform URL reachable FROM JarvisLab (provider.url in client config)
-# Mode A local node: e.g. http://100.x.x.x:8081 (Tailscale) or https://your-tunnel
-# Mode B hosted: https://core.inferoute.com
+# Set after ngrok starts — copy the https://….ngrok… URL (no trailing slash)
 export INFEROUTE_PLATFORM_URL=""
 
-# Consumer API on your Mac (inferoute-node)
-export INFEROUTE_CONSUMER_URL="http://localhost:8081"
+# ngrok on Mac — inferoute-node docker listens on port 80
+# Override if you use a reserved domain or different flags
+export NGROK_CMD="ngrok http 80"
+
+# Consumer API on Mac (inferoute-node docker, port 80)
+export INFEROUTE_CONSUMER_URL="http://localhost"
 
 # API keys from inferoute platform
 export PROVIDER_API_KEY=""
@@ -20,5 +23,5 @@ export CONSUMER_API_KEY=""
 # vLLM on JarvisLab
 export VLLM_MODEL="Qwen/Qwen3-0.6B"
 
-# Model alias as registered on the platform (from approved-builds / health report)
-export INFEROUTE_MODEL_ALIAS=""
+# Model alias — set after client health shows verified model, or use vLLM model id
+export INFEROUTE_MODEL_ALIAS="Qwen/Qwen3-0.6B"

--- a/skills/inferoute-e2e-integration-test/references/env.example
+++ b/skills/inferoute-e2e-integration-test/references/env.example
@@ -1,0 +1,24 @@
+# Copy to ~/.config/inferoute/e2e.env and source before running the skill.
+# NEVER commit filled secrets.
+
+# JarvisLab
+export JL_MACHINE_ID=""          # jl list --json
+export JL_GPU=""                 # optional: L4, A100, etc.
+
+# Platform URL reachable FROM JarvisLab (provider.url in client config)
+# Mode A local node: e.g. http://100.x.x.x:8081 (Tailscale) or https://your-tunnel
+# Mode B hosted: https://core.inferoute.com
+export INFEROUTE_PLATFORM_URL=""
+
+# Consumer API on your Mac (inferoute-node)
+export INFEROUTE_CONSUMER_URL="http://localhost:8081"
+
+# API keys from inferoute platform
+export PROVIDER_API_KEY=""
+export CONSUMER_API_KEY=""
+
+# vLLM on JarvisLab
+export VLLM_MODEL="Qwen/Qwen3-0.6B"
+
+# Model alias as registered on the platform (from approved-builds / health report)
+export INFEROUTE_MODEL_ALIAS=""

--- a/skills/inferoute-e2e-integration-test/references/env.example
+++ b/skills/inferoute-e2e-integration-test/references/env.example
@@ -5,13 +5,11 @@
 export JL_MACHINE_ID="433049"
 export JL_GPU=""                 # optional: L4, A100, etc.
 
-# Platform URL reachable FROM JarvisLab (provider.url in client config)
-# Set after ngrok starts — copy the https://….ngrok… URL (no trailing slash)
-export INFEROUTE_PLATFORM_URL=""
+# Platform URL — reserved ngrok domain (stable; no need to copy from ngrok UI each run)
+export INFEROUTE_PLATFORM_URL="https://saussuritic-ordinarily-sheldon.ngrok-free.dev"
 
 # ngrok on Mac — inferoute-node docker listens on port 80
-# Override if you use a reserved domain or different flags
-export NGROK_CMD="ngrok http 80"
+export NGROK_CMD="ngrok http 80 --host-header=localhost --url=saussuritic-ordinarily-sheldon.ngrok-free.dev"
 
 # Consumer API on Mac (inferoute-node docker, port 80)
 export INFEROUTE_CONSUMER_URL="http://localhost"

--- a/skills/inferoute-e2e-integration-test/references/inferoute-node-local.md
+++ b/skills/inferoute-e2e-integration-test/references/inferoute-node-local.md
@@ -1,0 +1,65 @@
+# inferoute-node on local Mac (consumer side)
+
+inferoute-node is **not** in the inferoute-client repo. Use your local `inferoute-node` checkout.
+
+## Expected role in E2E test
+
+| Component | Runs on | Purpose |
+|-----------|---------|---------|
+| inferoute-node | Mac | Consumer OpenAI-compatible API, routing, HMAC signing |
+| inferoute-client | JarvisLab | Provider agent, tunnel, vLLM proxy |
+| vLLM | JarvisLab | Model inference |
+
+## Typical local startup
+
+Adjust paths/ports to match your node repo:
+
+```bash
+cd inferoute-node
+# docker compose (preferred if documented in node repo)
+docker compose -f docker/env/development.yml up -d
+
+# OR go run (example — confirm in node README)
+go run ./cmd/... 
+```
+
+Set `INFEROUTE_CONSUMER_URL` to the consumer API port (commonly `8080` or `8081`).
+
+## Critical: JarvisLab must reach the platform URL
+
+When running a **local** node (not core.inferoute.com), set:
+
+```bash
+export INFEROUTE_PLATFORM_URL="http://<mac-reachable-host>:<platform-port>"
+```
+
+Options:
+
+1. **Tailscale** (recommended) — install on Mac and JarvisLab; use Mac Tailscale IP.
+2. **Cloudflare tunnel on Mac** — expose local node HTTPS URL.
+3. **Staging** — skip local node; use `https://core.inferoute.com` for both sides.
+
+Verify from JarvisLab before starting inferoute-client:
+
+```bash
+jl exec "$JL_MACHINE_ID" -- curl -sf "$INFEROUTE_PLATFORM_URL/api/health" || \
+jl exec "$JL_MACHINE_ID" -- curl -sf -o /dev/null -w "%{http_code}\n" "$INFEROUTE_PLATFORM_URL"
+```
+
+## Consumer API endpoints to confirm in node OpenAPI
+
+Document these from `inferoute-node/docs/swagger.json` (paths may vary by version):
+
+- `GET /v1/models`
+- `POST /v1/chat/completions` (sync + `stream: true`)
+- `POST /v1/completions` (sync + `stream: true`)
+
+Auth header: typically `Authorization: Bearer <consumer_api_key>`.
+
+## Pre-flight on Mac
+
+```bash
+curl -s "$INFEROUTE_CONSUMER_URL/health" || curl -s "$INFEROUTE_CONSUMER_URL/api/health"
+```
+
+Update this file once your node local-dev port and health path are confirmed.

--- a/skills/inferoute-e2e-integration-test/references/inferoute-node-local.md
+++ b/skills/inferoute-e2e-integration-test/references/inferoute-node-local.md
@@ -1,65 +1,66 @@
 # inferoute-node on local Mac (consumer side)
 
-inferoute-node is **not** in the inferoute-client repo. Use your local `inferoute-node` checkout.
+inferoute-node runs in **Docker on port 80** on the Mac.
 
-## Expected role in E2E test
+## Roles
 
-| Component | Runs on | Purpose |
-|-----------|---------|---------|
-| inferoute-node | Mac | Consumer OpenAI-compatible API, routing, HMAC signing |
-| inferoute-client | JarvisLab | Provider agent, tunnel, vLLM proxy |
-| vLLM | JarvisLab | Model inference |
+| Component | Where | Purpose |
+|-----------|-------|---------|
+| inferoute-node | Mac docker `:80` | Consumer API + platform (provider registration) |
+| ngrok | Mac | Exposes `:80` to JarvisLab as `INFEROUTE_PLATFORM_URL` |
+| inferoute-client | JarvisLab | Provider agent → vLLM |
+| vLLM | JarvisLab | `Qwen/Qwen3-0.6B` |
 
-## Typical local startup
-
-Adjust paths/ports to match your node repo:
-
-```bash
-cd inferoute-node
-# docker compose (preferred if documented in node repo)
-docker compose -f docker/env/development.yml up -d
-
-# OR go run (example — confirm in node README)
-go run ./cmd/... 
-```
-
-Set `INFEROUTE_CONSUMER_URL` to the consumer API port (commonly `8080` or `8081`).
-
-## Critical: JarvisLab must reach the platform URL
-
-When running a **local** node (not core.inferoute.com), set:
+## Startup
 
 ```bash
-export INFEROUTE_PLATFORM_URL="http://<mac-reachable-host>:<platform-port>"
+# inferoute-node (your usual docker compose / run command)
+docker compose up -d   # listens on localhost:80
+
+# ngrok (separate terminal)
+ngrok http 80
+# → set INFEROUTE_PLATFORM_URL to the https forwarding URL
 ```
 
-Options:
-
-1. **Tailscale** (recommended) — install on Mac and JarvisLab; use Mac Tailscale IP.
-2. **Cloudflare tunnel on Mac** — expose local node HTTPS URL.
-3. **Staging** — skip local node; use `https://core.inferoute.com` for both sides.
-
-Verify from JarvisLab before starting inferoute-client:
+## Env for this setup
 
 ```bash
-jl exec "$JL_MACHINE_ID" -- curl -sf "$INFEROUTE_PLATFORM_URL/api/health" || \
-jl exec "$JL_MACHINE_ID" -- curl -sf -o /dev/null -w "%{http_code}\n" "$INFEROUTE_PLATFORM_URL"
+export INFEROUTE_CONSUMER_URL="http://localhost"
+export NGROK_CMD="ngrok http 80"
+export INFEROUTE_PLATFORM_URL="https://xxxx.ngrok-free.app"   # from ngrok UI
+export JL_MACHINE_ID="433049"
+export VLLM_MODEL="Qwen/Qwen3-0.6B"
+export INFEROUTE_MODEL_ALIAS="Qwen/Qwen3-0.6B"   # adjust if health report shows different alias
 ```
 
-## Consumer API endpoints to confirm in node OpenAPI
+## API testing (curl + API keys only)
 
-Document these from `inferoute-node/docs/swagger.json` (paths may vary by version):
-
-- `GET /v1/models`
-- `POST /v1/chat/completions` (sync + `stream: true`)
-- `POST /v1/completions` (sync + `stream: true`)
-
-Auth header: typically `Authorization: Bearer <consumer_api_key>`.
-
-## Pre-flight on Mac
+No swagger needed. All consumer tests use `Authorization: Bearer $CONSUMER_API_KEY`.
 
 ```bash
-curl -s "$INFEROUTE_CONSUMER_URL/health" || curl -s "$INFEROUTE_CONSUMER_URL/api/health"
+# List models
+curl -s -H "Authorization: Bearer $CONSUMER_API_KEY" \
+  "$INFEROUTE_CONSUMER_URL/v1/models" | jq .
+
+# Chat (sync)
+curl -s -H "Authorization: Bearer $CONSUMER_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$INFEROUTE_CONSUMER_URL/v1/chat/completions" \
+  -d '{"model":"'"$INFEROUTE_MODEL_ALIAS"'","messages":[{"role":"user","content":"hi"}],"stream":false,"max_tokens":32}'
+
+# Chat (stream) — use -N
+curl -N -H "Authorization: Bearer $CONSUMER_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$INFEROUTE_CONSUMER_URL/v1/chat/completions" \
+  -d '{"model":"'"$INFEROUTE_MODEL_ALIAS"'","messages":[{"role":"user","content":"hi"}],"stream":true,"max_tokens":32}'
 ```
 
-Update this file once your node local-dev port and health path are confirmed.
+Full script: `references/test-inference.sh`
+
+## Pre-flight
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost/v1/models \
+  -H "Authorization: Bearer $CONSUMER_API_KEY"
+curl -s -o /dev/null -w "%{http_code}\n" "$INFEROUTE_PLATFORM_URL/api/health"
+```

--- a/skills/inferoute-e2e-integration-test/references/inferoute-node-local.md
+++ b/skills/inferoute-e2e-integration-test/references/inferoute-node-local.md
@@ -18,16 +18,16 @@ inferoute-node runs in **Docker on port 80** on the Mac.
 docker compose up -d   # listens on localhost:80
 
 # ngrok (separate terminal)
-ngrok http 80
-# → set INFEROUTE_PLATFORM_URL to the https forwarding URL
+eval "$NGROK_CMD"
+# default: ngrok http 80 --host-header=localhost --url=saussuritic-ordinarily-sheldon.ngrok-free.dev
 ```
 
 ## Env for this setup
 
 ```bash
 export INFEROUTE_CONSUMER_URL="http://localhost"
-export NGROK_CMD="ngrok http 80"
-export INFEROUTE_PLATFORM_URL="https://xxxx.ngrok-free.app"   # from ngrok UI
+export NGROK_CMD="ngrok http 80 --host-header=localhost --url=saussuritic-ordinarily-sheldon.ngrok-free.dev"
+export INFEROUTE_PLATFORM_URL="https://saussuritic-ordinarily-sheldon.ngrok-free.dev"
 export JL_MACHINE_ID="433049"
 export VLLM_MODEL="Qwen/Qwen3-0.6B"
 export INFEROUTE_MODEL_ALIAS="Qwen/Qwen3-0.6B"   # adjust if health report shows different alias

--- a/skills/inferoute-e2e-integration-test/references/jarvislab-provider-setup.sh
+++ b/skills/inferoute-e2e-integration-test/references/jarvislab-provider-setup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Run ON the JarvisLab instance (via jl ssh or upload + exec).
+# Idempotent bootstrap for vLLM + inferoute-client.
+set -euo pipefail
+
+: "${PROVIDER_API_KEY:?}"
+: "${INFEROUTE_PLATFORM_URL:?}"
+: "${VLLM_MODEL:?}"
+
+LOG_DIR=/home/inferoute/logs
+mkdir -p "$LOG_DIR" /home/inferoute/bin
+
+if ! command -v vllm >/dev/null 2>&1; then
+  pip install -q 'vllm>=0.8.0'
+fi
+
+if ! pgrep -f "vllm serve" >/dev/null; then
+  nohup vllm serve "$VLLM_MODEL" --host 0.0.0.0 --port 8000 \
+    >"$LOG_DIR/vllm.log" 2>&1 &
+fi
+
+for i in $(seq 1 40); do
+  curl -sf http://127.0.0.1:8000/v1/models >/dev/null && break
+  sleep 15
+done
+
+if ! command -v inferoute-client >/dev/null 2>&1; then
+  export PROVIDER_TYPE=vllm LLM_URL=http://127.0.0.1:8000 SERVER_PORT=8080
+  curl -fsSL https://raw.githubusercontent.com/inferoute/inferoute-client/main/scripts/install.sh | bash
+fi
+
+mkdir -p ~/.config/inferoute
+cat >~/.config/inferoute/config.yaml <<EOF
+server:
+  port: 8080
+  host: "0.0.0.0"
+provider:
+  api_key: "$PROVIDER_API_KEY"
+  url: "$INFEROUTE_PLATFORM_URL"
+  provider_type: vllm
+  llm_url: http://127.0.0.1:8000
+logging:
+  level: info
+EOF
+
+if ! pgrep -x inferoute-client >/dev/null; then
+  nohup inferoute-client --config ~/.config/inferoute/config.yaml \
+    >"$LOG_DIR/inferoute-client.log" 2>&1 &
+fi
+
+echo "vLLM models:" && curl -s http://127.0.0.1:8000/v1/models | head -c 400
+echo ""
+echo "Client health:" && curl -s http://127.0.0.1:8080/api/health | head -c 600

--- a/skills/inferoute-e2e-integration-test/references/ngrok.md
+++ b/skills/inferoute-e2e-integration-test/references/ngrok.md
@@ -12,24 +12,20 @@ Mac consumer tests          ──HTTP───►  http://localhost     (same d
 ## Environment (this setup)
 
 ```bash
-export JL_MACHINE_ID="433049"
-export NGROK_CMD="ngrok http 80"
+export NGROK_CMD="ngrok http 80 --host-header=localhost --url=saussuritic-ordinarily-sheldon.ngrok-free.dev"
+export INFEROUTE_PLATFORM_URL="https://saussuritic-ordinarily-sheldon.ngrok-free.dev"
 export INFEROUTE_CONSUMER_URL="http://localhost"
-
-# After ngrok starts — paste the https forwarding URL:
-export INFEROUTE_PLATFORM_URL="https://xxxx.ngrok-free.app"
 ```
+
+Reserved domain → `INFEROUTE_PLATFORM_URL` is stable; no need to copy from ngrok UI each run.
 
 ## Start ngrok (Mac)
 
 ```bash
 eval "$NGROK_CMD"
-# default: ngrok http 80
 ```
 
-If you use a custom command (reserved domain, config file, etc.), set `NGROK_CMD` in `e2e.env` and run that instead.
-
-Keep ngrok running for the whole E2E test.
+Keep ngrok running for the whole E2E test. Stop with `Ctrl+C` during teardown.
 
 ## Verify
 
@@ -50,6 +46,5 @@ Do not start inferoute-client on JarvisLab until the JarvisLab curl succeeds.
 
 ## Notes
 
-- `INFEROUTE_PLATFORM_URL` = ngrok **https** URL (for JarvisLab → Mac).
+- `--host-header=localhost` required so docker/nginx on port 80 accepts the request.
 - Consumer inference tests use **localhost** only — ngrok is provider/platform traffic.
-- Teardown: `Ctrl+C` ngrok when done.

--- a/skills/inferoute-e2e-integration-test/references/ngrok.md
+++ b/skills/inferoute-e2e-integration-test/references/ngrok.md
@@ -1,0 +1,55 @@
+# ngrok on local Mac (expose inferoute-node to JarvisLab)
+
+JarvisLab cannot reach your Mac directly. **ngrok** exposes inferoute-node (docker on **port 80**) so inferoute-client on JarvisLab can call `provider.url`.
+
+## Flow
+
+```text
+JarvisLab inferoute-client  ──HTTPS──►  ngrok public URL  ──►  Mac localhost:80 (docker inferoute-node)
+Mac consumer tests          ──HTTP───►  http://localhost     (same docker, no ngrok)
+```
+
+## Environment (this setup)
+
+```bash
+export JL_MACHINE_ID="433049"
+export NGROK_CMD="ngrok http 80"
+export INFEROUTE_CONSUMER_URL="http://localhost"
+
+# After ngrok starts — paste the https forwarding URL:
+export INFEROUTE_PLATFORM_URL="https://xxxx.ngrok-free.app"
+```
+
+## Start ngrok (Mac)
+
+```bash
+eval "$NGROK_CMD"
+# default: ngrok http 80
+```
+
+If you use a custom command (reserved domain, config file, etc.), set `NGROK_CMD` in `e2e.env` and run that instead.
+
+Keep ngrok running for the whole E2E test.
+
+## Verify
+
+**Mac (after docker + ngrok up):**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" "$INFEROUTE_PLATFORM_URL/api/health"
+curl -s -H "Authorization: Bearer $CONSUMER_API_KEY" "$INFEROUTE_CONSUMER_URL/v1/models" | jq .
+```
+
+**JarvisLab (after `jl resume`):**
+
+```bash
+jl exec "$JL_MACHINE_ID" -- curl -sf -o /dev/null -w "%{http_code}\n" "$INFEROUTE_PLATFORM_URL/api/health"
+```
+
+Do not start inferoute-client on JarvisLab until the JarvisLab curl succeeds.
+
+## Notes
+
+- `INFEROUTE_PLATFORM_URL` = ngrok **https** URL (for JarvisLab → Mac).
+- Consumer inference tests use **localhost** only — ngrok is provider/platform traffic.
+- Teardown: `Ctrl+C` ngrok when done.

--- a/skills/inferoute-e2e-integration-test/references/teardown.sh
+++ b/skills/inferoute-e2e-integration-test/references/teardown.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Stop JarvisLab provider processes and pause the instance.
+# Usage: source ~/.config/inferoute/e2e.env && ./teardown.sh
+set -euo pipefail
+
+: "${JL_MACHINE_ID:?set JL_MACHINE_ID in e2e.env}"
+
+echo "=== Teardown: JarvisLab $JL_MACHINE_ID ==="
+
+status=$(jl get "$JL_MACHINE_ID" --json 2>/dev/null | jq -r '.status // empty' || true)
+if [ "$status" = "Running" ]; then
+  echo "Stopping inferoute-client and vLLM..."
+  jl exec "$JL_MACHINE_ID" -- sh -lc \
+    'pkill -x inferoute-client 2>/dev/null || true; pkill -f "vllm serve" 2>/dev/null || true' \
+    || echo "warn: could not exec stop commands (instance may be unreachable)"
+else
+  echo "Instance status: ${status:-unknown} — skipping remote process stop"
+fi
+
+echo "Pausing instance (stops compute billing)..."
+jl pause "$JL_MACHINE_ID" --yes
+
+echo "Done. $JL_MACHINE_ID is paused."

--- a/skills/inferoute-e2e-integration-test/references/test-inference.sh
+++ b/skills/inferoute-e2e-integration-test/references/test-inference.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Mac-side inference smoke tests. Usage: source e2e.env && ./test-inference.sh
+set -euo pipefail
+
+: "${INFEROUTE_CONSUMER_URL:?}"
+: "${CONSUMER_API_KEY:?}"
+: "${INFEROUTE_MODEL_ALIAS:?}"
+
+BASE="${INFEROUTE_CONSUMER_URL%/}"
+AUTH=(-H "Authorization: Bearer ${CONSUMER_API_KEY}" -H "Content-Type: application/json")
+
+pass=0
+fail=0
+
+check() {
+  local name="$1" code="$2"
+  if [ "$code" -eq 0 ]; then
+    echo "PASS  $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  $name"
+    fail=$((fail + 1))
+  fi
+}
+
+echo "=== GET /v1/models ==="
+if curl -sf "${AUTH[@]}" "$BASE/v1/models" | jq -e '.data | length > 0' >/dev/null; then
+  check "models list" 0
+else
+  check "models list" 1
+fi
+
+echo "=== POST /v1/chat/completions (sync) ==="
+resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" "$BASE/v1/chat/completions" \
+  -d '{"model":"'"$INFEROUTE_MODEL_ALIAS"'","messages":[{"role":"user","content":"Reply with exactly: inferoute-ok"}],"stream":false,"max_tokens":32}')
+body=$(echo "$resp" | sed '$d')
+code=$(echo "$resp" | tail -1)
+if [ "$code" = "200" ] && echo "$body" | jq -e '.choices[0].message.content' >/dev/null; then
+  check "chat sync" 0
+  echo "$body" | jq -r '.choices[0].message.content'
+else
+  check "chat sync" 1
+  echo "$body"
+fi
+
+echo "=== POST /v1/completions (sync) ==="
+resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" "$BASE/v1/completions" \
+  -d '{"model":"'"$INFEROUTE_MODEL_ALIAS"'","prompt":"Reply with exactly: inferoute-ok","stream":false,"max_tokens":32}' 2>/dev/null || true)
+if [ -n "$resp" ]; then
+  body=$(echo "$resp" | sed '$d')
+  code=$(echo "$resp" | tail -1)
+  if [ "$code" = "200" ]; then
+    check "completions sync" 0
+  elif [ "$code" = "404" ]; then
+    echo "SKIP  completions sync (endpoint not exposed)"
+  else
+    check "completions sync" 1
+    echo "$body"
+  fi
+else
+  echo "SKIP  completions sync"
+fi
+
+echo "=== POST /v1/chat/completions (stream) ==="
+stream_out=$(curl -N -s -w "\nHTTP_CODE:%{http_code}" "${AUTH[@]}" "$BASE/v1/chat/completions" \
+  -d '{"model":"'"$INFEROUTE_MODEL_ALIAS"'","messages":[{"role":"user","content":"Say hello"}],"stream":true,"max_tokens":32}' | tee /dev/stderr)
+if echo "$stream_out" | grep -q 'data: \[DONE\]' || echo "$stream_out" | grep -q 'data:{'; then
+  check "chat stream" 0
+else
+  check "chat stream" 1
+fi
+
+echo "=== POST /v1/completions (stream) ==="
+stream_out=$(curl -N -s "${AUTH[@]}" "$BASE/v1/completions" \
+  -d '{"model":"'"$INFEROUTE_MODEL_ALIAS"'","prompt":"Say hello","stream":true,"max_tokens":32}' 2>/dev/null || true)
+if [ -z "$stream_out" ]; then
+  echo "SKIP  completions stream"
+elif echo "$stream_out" | grep -q 'data: \[DONE\]' || echo "$stream_out" | grep -q 'data:{'; then
+  check "completions stream" 0
+else
+  check "completions stream" 1
+fi
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

E2E skill for testing **inferoute-client** (JarvisLab) against **inferoute-node** (local Mac docker).

## Configured for this environment

| Setting | Value |
|---------|-------|
| `JL_MACHINE_ID` | `433049` |
| inferoute-node | Docker on Mac port **80** |
| Mac reachability | **ngrok** (`ngrok http 80`) |
| vLLM model | `Qwen/Qwen3-0.6B` |
| Consumer tests | curl + `Authorization: Bearer $CONSUMER_API_KEY` |

## What's included

- `skills/inferoute-e2e-integration-test/SKILL.md` — full workflow
- `references/env.example` — pre-filled defaults (keys still blank)
- `references/ngrok.md` — ngrok setup for port 80
- `references/test-inference.sh` — Mac-side smoke tests

## Usage

```bash
cp skills/inferoute-e2e-integration-test/references/env.example ~/.config/inferoute/e2e.env
# add PROVIDER_API_KEY + CONSUMER_API_KEY, start docker + ngrok, paste ngrok URL
source ~/.config/inferoute/e2e.env
```

Then invoke: **"test inferoute e2e"**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1cb0-5127-7210-8761-d85408717702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1cb0-5127-7210-8761-d85408717702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

